### PR TITLE
Without immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "babel-register": "^6.6.0",
     "deep-assign": "2.0.0",
-    "immutable": "^3.7.5",
     "invariant": "^2.2.0",
     "lodash": "4.13.1",
     "react": "^0.14.3 || ^15.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "babel-register": "^6.6.0",
-    "deep-assign": "2.0.0",
     "invariant": "^2.2.0",
     "lodash": "4.13.1",
     "react": "^0.14.3 || ^15.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "transpiled/index.js",
   "scripts": {
     "prepublish": "$(npm bin)/babel -d transpiled src",
-    "test": "$(npm bin)/mocha  --compilers js:babel-register --recursive --require ./test/setup.js"
+    "test": "$(npm bin)/mocha --compilers js:babel-register -w --recursive --require ./test/setup.js"
   },
   "repository": {
     "type": "git",
@@ -37,8 +37,10 @@
   },
   "dependencies": {
     "babel-register": "^6.6.0",
+    "deep-assign": "2.0.0",
     "immutable": "^3.7.5",
     "invariant": "^2.2.0",
+    "lodash": "4.13.1",
     "react": "^0.14.3 || ^15.0.1",
     "react-redux": "^4.0.0",
     "redux": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "redux-ui",
-  "version": "0.0.15",
+  "name": "@rcsole/redux-ui",
+  "version": "1.0.0",
   "description": "UI state management for Redux and React",
   "main": "transpiled/index.js",
   "scripts": {

--- a/src/action-reducer.js
+++ b/src/action-reducer.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import { Map } from 'immutable';
-import invariant from 'invariant'
+import _ from 'lodash/fp';
+import deepAssign from 'deep-assign';
+import invariant from 'invariant';
 
 // For updating multiple UI variables at once.  Each variable might be part of
 // a different context; this means that we need to either call updateUI on each
@@ -16,16 +17,16 @@ export const SET_DEFAULT_UI_STATE = '@@redux-ui/SET_DEFAULT_UI_STATE';
 const MOUNT_UI_STATE = '@@redux-ui/MOUNT_UI_STATE';
 const UNMOUNT_UI_STATE = '@@redux-ui/UNMOUNT_UI_STATE';
 
-export const defaultState = new Map({
-  __reducers: new Map({
-    // This contains a map of component paths (joined by '.') to an object
+export const defaultState = {
+  __reducers: {
+    // This contains an object of component paths (joined by '.') to an object
     // containing the fully qualified path and the reducer function:
     // 'parent.child': {
     //   path: ['parent', 'child'],
     //   func: (state, action) => { ... }
     // }
-  })
-});
+  }
+};
 
 export default function reducer(state = defaultState, action) {
   let key = action.payload && (action.payload.key || []);
@@ -37,92 +38,69 @@ export default function reducer(state = defaultState, action) {
   switch (action.type) {
     case UPDATE_UI_STATE:
       const { name, value } = action.payload;
-      state = state.setIn(key.concat(name), value);
+      state = _.set(key.concat(name), value, state);
       break;
 
     case MASS_UPDATE_UI_STATE:
       const { uiVars, transforms } = action.payload;
-      state = state.withMutations( s => {
-        Object.keys(transforms).forEach(k => {
-          const path = uiVars[k];
-          invariant(
-            path,
-            `Couldn't find variable ${k} within your component's UI state ` +
-            `context. Define ${k} before using it in the @ui decorator`
-          );
+      let s = Object.assign({}, state);
 
-          s.setIn(path.concat(k), transforms[k]);
-        });
+      Object.keys(transforms).forEach(k => {
+        const path = uiVars[k];
+        invariant(
+          path,
+          `Couldn't find variable ${k} within your component's UI state ` +
+          `context. Define ${k} before using it in the @ui decorator`
+        );
+
+        s = _.set(path.concat(k), transforms[k], s);
       });
+
+      state = Object.assign({}, s)
       break;
 
     case SET_DEFAULT_UI_STATE:
       // Replace all UI under a key with the given values
-      state = state.setIn(key, new Map(action.payload.value));
+      state = _.set(key, action.payload.value, state);
       break;
 
     case MOUNT_UI_STATE:
       const { defaults, customReducer } = action.payload;
-      state = state.withMutations( s => {
-        // Set the defaults for the component
-        s.setIn(key, new Map(defaults));
+      state = _.set(key, defaults, state)
 
-        // If this component has a custom reducer add it to the list.
-        // We store the reducer func and UI path for the current component
-        // inside the __reducers map.
-        if (customReducer) {
-          let path = key.join('.');
-          s.setIn(['__reducers', path], {
-            path: key,
-            func: customReducer
-          });
-        }
-
-        return s;
-      });
+      if (customReducer) {
+        let path = key.join('.');
+        console.log()
+        state = _.set(['__reducers', path], {
+          path: key,
+          func: customReducer
+        }, state);
+      }
       break;
 
     case UNMOUNT_UI_STATE:
       // We have to use deleteIn as react unmounts root components first;
       // this means that using setIn in child contexts will fail as the root
       // context will be stored as undefined in our state
-      state= state.withMutations(s => {
-        s.deleteIn(key);
-        // Remove any custom reducers
-        s.deleteIn(['__reducers', key.join('.')]);
-      });
+      state = _.unset(key, state)
+      state = _.unset(['__reducers', key.join('.')], state)
       break;
   }
 
-  const customReducers = state.get('__reducers');
-  if (customReducers.size > 0) {
-    state = state.withMutations(mut => {
-      customReducers.forEach(r => {
-        // This calls each custom reducer with the UI state for each custom
-        // reducer with the component's UI state tree passed into it.
-        //
-        // NOTE: Each component's reducer gets its own UI state: not the entire
-        // UI reducer's state. Whatever is returned from this reducer is set
-        // within the **components** UI scope.
-        //
-        // This is because it's the only way to update UI state for components
-        // without keys - you need to know the path in advance to update state
-        // from a reducer.  If you have list of components with no UI keys in
-        // the component heirarchy, any children will not be able to use custom
-        // reducers as the path is random.
-        //
-        // TODO: Potentially add the possibility for a global UI state reducer?
-        //       Though why wouldn't you just add a custom reducer to the
-        //       top-level component?
-        const { path, func } = r;
-        const newState = func(mut.getIn(path), action);
-        if (newState === undefined) {
-          throw new Error(`Your custom UI reducer at path ${path.join('.')} must return some state`);
-        }
-        mut.setIn(path, newState);
-      });
-      return mut;
+  const customReducers = state['__reducers'];
+  if (_.size(customReducers) > 0) {
+    let s = Object.assign({}, state);
+    Object.keys(customReducers).forEach((k) => {
+      const { path, func } = customReducers[k];
+      const newState = func(_.get(path, s), action);
+      if (newState === undefined) {
+        throw new Error(`Your custom UI reducer at path ${path.join('.')} must return some state`);
+      }
+      // console.log(newState);
+      s = _.set(path, newState, s);
     });
+
+    state = Object.assign({}, s);
   }
 
   return state;

--- a/src/action-reducer.js
+++ b/src/action-reducer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import _ from 'lodash/fp';
-import deepAssign from 'deep-assign';
 import invariant from 'invariant';
 
 // For updating multiple UI variables at once.  Each variable might be part of

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,6 +3,7 @@
 import React, { Component, PropTypes } from 'react';
 const { any, array, func, node, object, string } = PropTypes;
 import { bindActionCreators } from 'redux';
+import _ from 'lodash/fp';
 import { connect } from 'react-redux';
 import invariant from 'invariant';
 import { updateUI, massUpdateUI, setDefaultUI, mountUI, unmountUI } from './action-reducer';
@@ -119,7 +120,7 @@ export default function ui(key, opts = {}) {
         componentWillMount() {
           // If the component's UI subtree doesn't exist and we have state to
           // set ensure we update our global store with the current state.
-          if (this.props.ui.getIn(this.uiPath) === undefined && opts.state) {
+          if (_.get(this.uiPath, this.props.ui) === undefined && opts.state) {
             const state = this.getDefaultUIState(opts.state);
             this.context.store.dispatch(mountUI(this.uiPath, state, opts.reducer));
           }
@@ -135,7 +136,7 @@ export default function ui(key, opts = {}) {
           // accessing the current global UI state; the parent will not
           // necessarily always pass down child state.
           const ui = getUIState(this.context.store.getState());
-          if (ui.getIn(this.uiPath) === undefined && opts.state) {
+          if (_.get(this.uiPath, ui) === undefined && opts.state) {
             const state = this.getDefaultUIState(opts.state, nextProps);
             this.props.setDefaultUI(this.uiPath, state);
           }
@@ -281,7 +282,7 @@ export default function ui(key, opts = {}) {
           const ui = getUIState(this.context.store.getState());
 
           return Object.keys(this.uiVars).reduce((props, k) => {
-            props[k] = ui.getIn(this.uiVars[k].concat(k));
+            props[k] = _.get(this.uiVars[k].concat(k), ui);
             return props;
           }, {}) || {};
         }

--- a/test/action-reducer/reducer.js
+++ b/test/action-reducer/reducer.js
@@ -7,14 +7,14 @@ import {
 } from '../../src/action-reducer.js';
 
 import { assert } from 'chai';
-import { is, Map } from 'immutable';
+import _ from 'lodash/fp';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 import { defaultState } from '../../src/action-reducer.js';
 
 const customReducer = (state, action) => {
   if (action.type === 'CUSTOM_ACTION_TYPE') {
-    return state.set('isHooked', true);
+    return _.set('isHooked', true, state);
   }
   return state;
 }
@@ -22,13 +22,13 @@ const enhancedReducer = reducerEnhancer(customReducer);
 
 describe('reducerEnhancer', () => {
   let enhancedStore;
-  
+
   beforeEach( () => {
     enhancedStore = createStore(combineReducers({ ui: enhancedReducer }));
   });
 
   it('delegates to the default reducer', () => {
-    assert.isTrue(is(enhancedStore.getState().ui, defaultState));
+    assert.isTrue(_.isEqual(enhancedStore.getState().ui, defaultState));
 
     enhancedStore.dispatch({
       type: UPDATE_UI_STATE,
@@ -40,18 +40,18 @@ describe('reducerEnhancer', () => {
     });
 
     assert.isTrue(
-      is(
+      _.isEqual(
         enhancedStore.getState().ui,
-        new Map({
-          __reducers: new Map(),
-          a: new Map({ foo: 'bar' })
-        })
+        {
+          __reducers: {},
+          a: { foo: 'bar' }
+        }
       )
     );
   });
 
   it('intercepts custom actions', () => {
-    assert.isTrue(is(enhancedStore.getState().ui, defaultState));
+    assert.isTrue(_.isEqual(enhancedStore.getState().ui, defaultState));
 
     enhancedStore.dispatch({
       type: 'CUSTOM_ACTION_TYPE',
@@ -60,12 +60,12 @@ describe('reducerEnhancer', () => {
       }
     });
     assert.isTrue(
-      is(
+      _.isEqual(
         enhancedStore.getState().ui,
-        new Map({
-          __reducers: new Map(),
+        {
+          __reducers: {},
           isHooked: true
-        })
+        }
       )
     );
   });

--- a/test/ui/context.js
+++ b/test/ui/context.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
@@ -26,7 +26,7 @@ describe('UI state context', () => {
       isValid: true
     };
     const UITest = ui({ state: uiState })(Test);
- 
+
     it('component gets given expected props', () => {
       const c = renderAndFind(<UITest />, Test);
       assert(typeof c.props.updateUI === 'function', 'has updateUI');
@@ -150,7 +150,7 @@ describe('UI state context', () => {
 
         assert(parent.props.ui.name === 'parent');
         assert(child.props.ui.name === 'child');
-      }); 
+      });
 
       it('parent updates context separately from parent', () => {
         const tree = render(UIChildJSX);
@@ -160,7 +160,7 @@ describe('UI state context', () => {
         parent.updateContext('foobar');
         assert(parent.props.ui.name === 'foobar');
         assert(child.props.ui.name === 'child');
-      }); 
+      });
 
 
       it('child updates context separately from parent', () => {
@@ -171,7 +171,7 @@ describe('UI state context', () => {
         child.updateChildContext('foobar');
         assert(parent.props.ui.name === 'parent');
         assert(child.props.ui.name === 'foobar');
-      }); 
+      });
     });
 
   });

--- a/test/ui/defaults.js
+++ b/test/ui/defaults.js
@@ -1,11 +1,10 @@
 
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
-import { Map } from 'immutable';
 
 import ui, { reducer } from '../../src';
 import { render, renderAndFind } from '../utils/render.js';
@@ -29,15 +28,14 @@ describe('Default UI state variables', () => {
       isValid: true
     };
     const UITest = ui({ state: uiState })(Test);
- 
+
     it('component gets given expected props', () => {
       const c = renderAndFind(<UITest passedProp='foo' />, Test);
       assert.equal(c.props.ui.calculated, 'foo');
       assert.equal(calcProps.passedProp, 'foo');
-      assert.equal(typeof calcState.ui, typeof Map());
+      assert.equal(typeof calcState.ui, typeof {});
     });
 
   });
 
 });
-

--- a/test/ui/reducer.js
+++ b/test/ui/reducer.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { is, Map } from 'immutable';
+import _ from 'lodash/fp';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
@@ -21,7 +21,7 @@ describe('with a custom reducer', () => {
   // UI variables
   let parentReducer = (state, action) => {
     if (action.type === 'CUSTOM') {
-      return state.set('name', 'parentOverride');
+      return _.set('name', 'parentOverride', state);
     }
     return state;
   };
@@ -36,14 +36,14 @@ describe('with a custom reducer', () => {
   it('adds a custom reducer on mount and removes at unmount', () => {
     const c = renderAndFind(<UIParent />, Parent);
 
-    let reducers = store.getState().ui.get('__reducers');
-    assert.equal(reducers.size, 1);
-    assert.equal(reducers.get('parent').func, parentReducer);
+    let reducers = store.getState().ui['__reducers'];
+    assert.equal(_.size(reducers), 1);
+    assert.equal(reducers.parent.func, parentReducer);
 
     // Unmount and this should be gone
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
-    reducers = store.getState().ui.get('__reducers');
-    assert.equal(reducers.size, 0);
+    reducers = store.getState().ui['__reducers'];
+    assert.equal(_.size(reducers), 0);
   });
 
   it('updates props as expected', () => {
@@ -75,7 +75,7 @@ describe('with a custom reducer', () => {
     let childReducer = (state = {}, action) => {
       reducerState = state;
       if (action.type === 'CUSTOM') {
-        return state.set('foo', 'childOverride');
+        return _.set('foo', 'childOverride', state);
       }
       return state;
     };
@@ -96,7 +96,7 @@ describe('with a custom reducer', () => {
       store.dispatch({ type: 'CUSTOM' });
       // The reducerState should equal the default reducer state for our child
       // component
-      assert.isTrue(is(reducerState, new Map({ foo: 'bar' })));
+      assert.isTrue(_.isEqual(reducerState, { foo: 'bar' }));
       assert.equal(parent.props.ui.name, 'parentOverride');
       assert.equal(child.props.ui.foo, 'childOverride');
 


### PR DESCRIPTION
Removes ImmutableJS dependency and uses `lodash` instead.
Temporary workaround until tonyhb/redux-ui#8 is fixed.
